### PR TITLE
Harden call to setActiveStepNo in next/prev

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ export default React.forwardRef(
       ref.current = {
           next: () => {
               if (steps.length - 1 !== activeStepNo) {
-                  setActiveStepNo(activeStepNo + 1)
+                  setActiveStepNo(activeStepNo => activeStepNo + 1)
                   setIsNext(true)
                   currentStep({
                       currentStep: activeStepNo + 1,
@@ -36,7 +36,7 @@ export default React.forwardRef(
           },
           prev: () => {
               if (activeStepNo > 0) {
-                  setActiveStepNo(activeStepNo - 1)
+                  setActiveStepNo(activeStepNo => activeStepNo - 1)
                   setIsNext(false)
                   currentStep({
                       currentStep: activeStepNo - 1,

--- a/react-native-wizard.d.ts
+++ b/react-native-wizard.d.ts
@@ -58,7 +58,7 @@ declare module "react-native-wizard" {
         /*
         Callback function run step change.
         */
-        currentStep: (payload: {
+        currentStep?: (payload: {
             currentStep: number;
             isFirstStep: boolean;
             isLastStep: boolean


### PR DESCRIPTION
Occasionally, `activeStepNo` wouldn't be updated correctly. In fact, the `useState` hook, when used to update the state using the previous state as an input (e.g. increment/decrement a counter like here), is better used with a function as a parameter and not a value. This also amends the TS definitions by correctly declaring `currentStep` as an optional prop.